### PR TITLE
Fix/rewrite image downsize error

### DIFF
--- a/wps3.php
+++ b/wps3.php
@@ -537,6 +537,12 @@ class WPS3 implements S3StorageInterface {
         if ($downsize !== false || !get_option('wps3_enabled') || empty($this->s3_client)) {
             return $downsize;
         }
+
+        // If $size is an array (e.g., [150, 150]), let WordPress handle it.
+        // Using an array as a key for $metadata['sizes'] causes a fatal error.
+        if (is_array($size)) {
+            return $downsize;
+        }
         
         // Get the metadata
         $metadata = wp_get_attachment_metadata($attachment_id);

--- a/wps3.php
+++ b/wps3.php
@@ -547,6 +547,12 @@ class WPS3 implements S3StorageInterface {
         // If size is the full size, use the attachment URL
         if ($size === 'full' || empty($metadata['sizes'][$size])) {
             $url = $this->rewrite_attachment_url(wp_get_attachment_url($attachment_id), $attachment_id);
+
+            // If a valid URL could not be determined, return original $downsize
+            if (!is_string($url) || empty($url)) {
+                return $downsize;
+            }
+
             $width = isset($metadata['width']) ? intval($metadata['width']) : 0;
             $height = isset($metadata['height']) ? intval($metadata['height']) : 0;
             return [$url, $width, $height, false];


### PR DESCRIPTION
This pull request introduces improvements to the `rewrite_image_downsize` function in `wps3.php` to enhance error handling and ensure compatibility with specific input types. The changes focus on preventing potential fatal errors and handling edge cases gracefully.

Error handling and compatibility improvements:

* Added a check to return early if `$size` is an array, preventing a fatal error caused by using an array as a key for `$metadata['sizes']`. (`[wps3.phpR541-R546](diffhunk://#diff-a1c5eb525be12d28b28615a2cc60d7b8225402ad95a04ba4506568a06c0c0c6bR541-R546)`)
* Introduced a validation step to ensure the generated URL is a non-empty string before proceeding. If the URL is invalid, the function now returns the original `$downsize` value. (`[wps3.phpR556-R561](diffhunk://#diff-a1c5eb525be12d28b28615a2cc60d7b8225402ad95a04ba4506568a06c0c0c6bR556-R561)`)