### PR TITLE
Fix: S3 thumbnail URLs not being rewritten correctly

### DIFF
--- a/wps3.php
+++ b/wps3.php
@@ -167,12 +167,16 @@ class WPS3
             $metadata = wp_get_attachment_metadata($attachment_id);
             if (!empty($metadata['sizes'])) {
                 $base_dir = trailingslashit(dirname($file_path));
-                foreach ($metadata['sizes'] as $size_data) {
+                foreach ($metadata['sizes'] as $size => &$size_data) {
                     $size_file_path = $base_dir . $size_data['file'];
                     if (file_exists($size_file_path)) {
-                        $this->s3_client_wrapper->upload_file($size_file_path);
+                        $s3_key = $this->s3_client_wrapper->upload_file($size_file_path);
+                        if ($s3_key) {
+                            $size_data['s3_key'] = $s3_key;
+                        }
                     }
                 }
+                wp_update_attachment_metadata($attachment_id, $metadata);
             }
         }
     }
@@ -235,7 +239,14 @@ class WPS3
         }
 
         if (is_string($size) && isset($meta['sizes'][$size])) {
-            $s3_key = dirname($s3_info['key']) . '/' . $meta['sizes'][$size]['file'];
+            $size_info = $meta['sizes'][$size];
+            if (isset($size_info['s3_key'])) {
+                $s3_key = $size_info['s3_key'];
+            } else {
+                // Fallback for older uploads
+                $s3_key = dirname($s3_info['key']) . '/' . $size_info['file'];
+            }
+
             $cdn_domain = get_option('wps3_cdn_domain');
 
             if (!empty($cdn_domain)) {
@@ -243,7 +254,7 @@ class WPS3
             } else {
                 $url = $this->s3_client_wrapper->get_s3_url($s3_key);
             }
-            return [$url, $meta['sizes'][$size]['width'], $meta['sizes'][$size]['height'], true];
+            return [$url, $size_info['width'], $size_info['height'], true];
         }
 
         return $downsize;


### PR DESCRIPTION
This pull request enhances the handling of attachment metadata and image downsizing for WordPress uploads stored on S3. The changes ensure that S3 keys for image sizes are stored and retrieved more efficiently, improving compatibility with older uploads and enabling better metadata updates.

### Enhancements to attachment metadata handling:

* [`wps3.php`](diffhunk://#diff-a1c5eb525be12d28b28615a2cc60d7b8225402ad95a04ba4506568a06c0c0c6bL170-R179): Updated `upload_attachment` to store the S3 key for each image size in the attachment metadata after uploading the file to S3. Also added a call to `wp_update_attachment_metadata` to persist these changes.

### Improvements to image downsizing logic:

* [`wps3.php`](diffhunk://#diff-a1c5eb525be12d28b28615a2cc60d7b8225402ad95a04ba4506568a06c0c0c6bL238-R257): Modified `rewrite_image_downsize` to prioritize the stored S3 key for retrieving image URLs. Added a fallback mechanism to handle older uploads that lack the `s3_key` metadata.